### PR TITLE
Url encode path and sort parameters for canonical_request.

### DIFF
--- a/httpx_auth_awssigv4/auth.py
+++ b/httpx_auth_awssigv4/auth.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 from datetime import datetime
 from typing import Optional
+from urllib.parse import quote, urlencode
 
 from httpx import Request
 
@@ -110,8 +111,10 @@ class SigV4Auth:
         Returns:
             str: request infromation in a canonical format
         """
-        canonical_uri = request.url.path
-        canonical_querystring = request.url.query.decode("utf-8")
+        # AWS calculates signature using url encoded path
+        canonical_uri = quote(request.url.path)
+        # Signature is also calculated using sorted params
+        canonical_querystring = urlencode(sorted(request.url.params.items()))
         canonical_headers = f"host:{request.url.host}\nx-amz-date:{timestamp}\n"
 
         if request.content:

--- a/httpx_auth_awssigv4/auth.py
+++ b/httpx_auth_awssigv4/auth.py
@@ -11,6 +11,7 @@ from typing import Optional
 from urllib.parse import quote, urlencode
 
 from httpx import Request
+from rfc3986 import normalize_uri
 
 
 class SigV4Auth:
@@ -112,7 +113,7 @@ class SigV4Auth:
             str: request infromation in a canonical format
         """
         # AWS calculates signature using url encoded path
-        canonical_uri = quote(request.url.path)
+        canonical_uri = quote(normalize_uri(request.url.path))
         # Signature is also calculated using sorted params
         canonical_querystring = urlencode(sorted(request.url.params.items()))
         canonical_headers = f"host:{request.url.host}\nx-amz-date:{timestamp}\n"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -47,7 +47,7 @@ def test_callable_permanent_creds(mock_dt, auth, access_key_id, access_token):
     assert signed_request.headers["authorization"] == (
         f"AWS4-HMAC-SHA256 Credential={access_key_id}/20200420/"
         f"{auth._region}/{auth._service}/aws4_request, SignedHeaders=host;x-amz-date, "
-        "Signature=8f841949ffd9e2f2ca5406f52cf5aa5e06b1d2ed8140b444d0ac46a845f627ec"
+        "Signature=2b0d23626261d2b9256a90dcb74bee78eae17dcf8b3e24b992406ae489d75cb4"
     )
 
     assert signed_request.headers["x-amz-security-token"] == access_token
@@ -71,7 +71,7 @@ def test_callable_sts_creds(mock_dt, auth, access_key_id):
     assert signed_request.headers["authorization"] == (
         f"AWS4-HMAC-SHA256 Credential={access_key_id}/20200420/"
         f"{auth._region}/{auth._service}/aws4_request, SignedHeaders=host;x-amz-date, "
-        "Signature=8f841949ffd9e2f2ca5406f52cf5aa5e06b1d2ed8140b444d0ac46a845f627ec"
+        "Signature=2b0d23626261d2b9256a90dcb74bee78eae17dcf8b3e24b992406ae489d75cb4"
     )
 
     assert "x-amz-security-token" not in signed_request.headers
@@ -96,7 +96,7 @@ def test_callable_sts_creds_post_call(mock_dt, auth, access_key_id):
     assert signed_request.headers["authorization"] == (
         f"AWS4-HMAC-SHA256 Credential={access_key_id}/20200420/"
         f"{auth._region}/{auth._service}/aws4_request, SignedHeaders=host;x-amz-date, "
-        "Signature=637069169cdbb543db43d56c43b10e43e4d256187dcbcef5a30d905eca8a8182"
+        "Signature=2e216177c15a81a721e56ce9489591b664109535709c12f69fe2e4472046b080"
     )
 
     assert "x-amz-security-token" not in signed_request.headers


### PR DESCRIPTION
AWS to calculate signature, uses URL encoded URL path. So in case URL contains any spacial chars, signature is not gonna match. Encoding URL before creating a request also doesn't work because then AWS will just URL encode it again adding more chars and changing signature. Another requirement for the valid signature is calculating it from sorted parameters.